### PR TITLE
Added clone in XMSS TW to allow parameter instantiation

### DIFF
--- a/proof/security/acai/XMSS_TW.ec
+++ b/proof/security/acai/XMSS_TW.ec
@@ -5,7 +5,8 @@ require (*--*) ROM.
 (*---*) import BS2Int.
 
 (* -- Local -- *)
-require import FL_XMSS_TW.
+require (*--*) FL_XMSS_TW.
+clone import FL_XMSS_TW as FLXMSSTW.
 require (*--*) DigitalSignatures DigitalSignaturesROM KeyedHashFunctions HashThenSign.
 (*---*) import SA WTW FLXMSSTW_EUFRMA.
 


### PR DESCRIPTION
When cloning XMSS TW to get an instance that is equivalent to the implementation we need to set some parameters in an underlying theory FL_XMSS_TW which was global.