### PR TITLE
Make explicit some alignment requirements

### DIFF
--- a/ref-jasmin/hash/hash.jinc
+++ b/ref-jasmin/hash/hash.jinc
@@ -16,7 +16,7 @@ fn __addr_to_bytes(
     while (i < 8) {
         subarray_start_index = i; subarray_start_index <<= 2; // subarray_start_index = i * 4
         buf = addr_as_bytes[subarray_start_index : 4];
-        buf = __u32_to_bytes(buf, addr[i]);
+        buf = __u32_to_bytes(buf, addr[#unaligned i]);
         addr_as_bytes[subarray_start_index : 4] = buf;
         i += 1;
     }

--- a/test/hash/test_hash.jazz
+++ b/test/hash/test_hash.jazz
@@ -45,6 +45,7 @@ fn hash_message_jazz(
     return mhash;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn thash_h_jazz(
     reg ptr u8[XMSS_N] out,
@@ -57,6 +58,7 @@ fn thash_h_jazz(
     return out, addr;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn thash_f_jazz(
     reg ptr u8[XMSS_N] out,

--- a/test/hash_address/test_hash_address.jazz
+++ b/test/hash_address/test_hash_address.jazz
@@ -1,5 +1,6 @@
 from XMSS require "hash_address/hash_address.jinc"
 
+#[required_alignment = { addr = u32 }]
 export
 fn set_layer_addr_jazz(
     reg ptr u32[8] addr, 
@@ -10,6 +11,7 @@ fn set_layer_addr_jazz(
     return addr;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn set_tree_addr_jazz(
     reg ptr u32[8] addr, 
@@ -20,6 +22,7 @@ fn set_tree_addr_jazz(
     return addr;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn set_type_jazz(
     reg ptr u32[8] addr, 
@@ -30,6 +33,7 @@ fn set_type_jazz(
     return addr;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn set_key_and_mask_jazz(
     reg ptr u32[8] addr, 
@@ -40,6 +44,7 @@ fn set_key_and_mask_jazz(
     return addr;
 }
 
+#[required_alignment = { in = u64, out = u64 }]
 export
 fn copy_subtree_addr_jazz(reg ptr u32[8] out in) -> reg ptr u32[8]
 {
@@ -47,6 +52,7 @@ fn copy_subtree_addr_jazz(reg ptr u32[8] out in) -> reg ptr u32[8]
     return out;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn set_ots_addr_jazz(
     reg ptr u32[8] addr, 
@@ -57,6 +63,7 @@ fn set_ots_addr_jazz(
     return addr;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn set_chain_addr_jazz(
     reg ptr u32[8] addr, 
@@ -67,6 +74,7 @@ fn set_chain_addr_jazz(
     return addr;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn set_hash_addr_jazz(
     reg ptr u32[8] addr, 
@@ -77,6 +85,7 @@ fn set_hash_addr_jazz(
     return addr;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn set_ltree_addr_jazz(
     reg ptr u32[8] addr, 
@@ -87,6 +96,7 @@ fn set_ltree_addr_jazz(
     return addr;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn set_tree_height_jazz(
     reg ptr u32[8] addr, 
@@ -97,6 +107,7 @@ fn set_tree_height_jazz(
     return addr;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn set_tree_index_jazz(
     reg ptr u32[8] addr, 

--- a/test/treehash/test_treehash.jazz
+++ b/test/treehash/test_treehash.jazz
@@ -21,6 +21,7 @@ fn build_auth_path_jazz(
     return auth_path;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn treesig_jazz(
     reg ptr u8[XMSS_WOTS_SIG_BYTES + (XMSS_TREE_HEIGHT * XMSS_N)] sig,  // wots signature + auth_path

--- a/test/wots/test_wots.jazz
+++ b/test/wots/test_wots.jazz
@@ -1,5 +1,6 @@
 from XMSS require "wots/wots.jinc"
 
+#[required_alignment = { addr = u32 }]
 export
 fn expand_seed_jazz(
     reg ptr u8[XMSS_WOTS_LEN * XMSS_N] outseeds,
@@ -11,6 +12,7 @@ fn expand_seed_jazz(
     return outseeds, addr;
 }
 
+#[required_alignment = { csum_base_w = u32, msg_base_w = u32 }]
 export
 fn wots_checksum_jazz(
     reg ptr u32[XMSS_WOTS_LEN2] csum_base_w,
@@ -21,6 +23,7 @@ fn wots_checksum_jazz(
     return csum_base_w;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn gen_chain_inplace_jazz(
     reg ptr u8[XMSS_N] out,
@@ -33,6 +36,7 @@ fn gen_chain_inplace_jazz(
     return out, addr;
 }
 
+#[required_alignment = { addr = u32 }]
 export
 fn gen_chain_jazz(
     reg ptr u8[XMSS_N] out,
@@ -47,6 +51,7 @@ fn gen_chain_jazz(
     return out, addr;
 } 
 
+#[required_alignment = { addr = u32 }]
 export
 fn wots_pkgen_jazz(
     reg ptr u8[XMSS_WOTS_LEN * XMSS_N] pk,
@@ -59,6 +64,7 @@ fn wots_pkgen_jazz(
     return pk, addr;
 } 
 
+#[required_alignment = { addr = u32 }]
 export
 fn wots_sign_jazz(
     reg ptr u8[XMSS_WOTS_LEN * XMSS_N] sig,
@@ -72,6 +78,7 @@ fn wots_sign_jazz(
     return sig, addr;
 }  
 
+#[required_alignment = { addr = u32 }]
 export
 fn wots_pk_from_sig_jazz(
     reg ptr u8[XMSS_WOTS_LEN * XMSS_N] pk,


### PR DESCRIPTION
The first commit removes an assumption about the memory alignment of some arrays. Please check if alignment was really expected there.

The second commits documents that some of the test functions do expect some of their arguments to be aligned. Please check that you are OK with these expectations. In particular, the requirement for `copy_subtree_addr_jazz` is surprising: you might prefer to relax it (either to 4 bytes or even down to 1 bytes, i.e., no requirement).

Note that future versions of the Jasmin compiler will require that the requirements on the alignment of the arguments to export functions be documented.